### PR TITLE
Start watchdog with 30s timeout on poweron

### DIFF
--- a/bin/chassis_control.py
+++ b/bin/chassis_control.py
@@ -18,6 +18,12 @@ POWER_ON = 1
 
 BOOTED = 100
 
+def getWatchdog():
+    obj =  bus.get_object('org.openbmc.watchdog.Host',
+            '/org/openbmc/watchdog/HostWatchdog_0')
+    intf = dbus.Interface(obj, 'org.openbmc.Watchdog' )
+    return intf
+
 class ChassisControlObject(dbus.service.Object):
 	def __init__(self,bus,name):
 		self.dbus_objects = { }
@@ -88,6 +94,11 @@ class ChassisControlObject(dbus.service.Object):
 		if (self.getPowerState()==0):
 			intf = self.getInterface('power_control')
 			intf.setPowerState(POWER_ON)
+			intfwatchdog = getWatchdog()
+			#Start watchdog with 30s timeout per the OpenPower Host IPMI Spec
+			#Once the host starts booting, it'll reset and refresh the timer
+			intfwatchdog.set(30000)
+			intfwatchdog.start()
 		return None
 
 	@dbus.service.method(DBUS_NAME,


### PR DESCRIPTION
Per the OpenPower Host IPMI Spec, start the watchdog from the BMC
with a 30s timeout at power on. Once the host starts booting, it
will reset it and refresh it.