### PR TITLE
Re-enable host watchdog

### DIFF
--- a/bin/chassis_control.py
+++ b/bin/chassis_control.py
@@ -188,8 +188,8 @@ class ChassisControlObject(Openbmc.DbusProperties,Openbmc.DbusObjectManager):
 		
 	def host_watchdog_signal_handler(self):
 		print "Watchdog Error, Hard Rebooting"
-		#self.Set(DBUS_NAME,"reboot",1)
-		#self.powerOff()
+		self.Set(DBUS_NAME,"reboot",1)
+		self.powerOff()
 		
 
 if __name__ == '__main__':


### PR DESCRIPTION
This fix is for workitem: 143559. The code is commented out due to a bug.
That bug has been fixed already. I tested on Palmetto and Barreleye, by
repeatly calling "obmcutil poweron / obmcutil poweroff" with a script.
Journalctrl shows no "Watchdog Err" message. So re-enable the host wdt.