### PR TITLE
skeleton: Rewrite setValue() method for Dbus object /org/openbmc/sens…

### DIFF
--- a/bin/Sensors.py
+++ b/bin/Sensors.py
@@ -1,6 +1,7 @@
 #!/usr/bin/python -u
 
 import sys
+import subprocess
 #from gi.repository import GObject
 import gobject
 import dbus
@@ -133,10 +134,23 @@ class HwmonSensor(SensorValue,SensorThresholds):
 		
 CONTROL_IFACE = 'org.openbmc.Control'
 class PowerCap(VirtualSensor):
-	def __init__(self,bus,name):
-		VirtualSensor.__init__(self,bus,name)
-		self.setValue(100)
-
+	def __init__(self, bus, name):
+		VirtualSensor.__init__(self, bus, name)
+		SensorValue.setValue(self, 0)
+		self.sysfs_attr = "/sys/class/hwmon/hwmon3/user_powercap"
+	##override setValue method
+	@dbus.service.method(SensorValue.IFACE_NAME,
+		in_signature='v', out_signature='')
+	def setValue(self, value):
+		try:
+			cmd_str = "echo "+str(value)+" > "+self.sysfs_attr
+			ret = subprocess.check_output(cmd_str, shell=True)
+		except subprocess.CalledProcessError as powerexc:
+			print "Set PowerCap Error", powerexc.returncode,
+			powerexc.output
+			return
+		print "Set PowerCap: ", value
+		SensorValue.setValue(self, value)
 		
 class BootProgressSensor(VirtualSensor):
 	def __init__(self,bus,name):

--- a/bin/sensor_manager2.py
+++ b/bin/sensor_manager2.py
@@ -53,7 +53,12 @@ if __name__ == '__main__':
 	## TODO: this should not be hardcoded
 
 	obj_path = OBJ_PATH+"/host/PowerCap"
-	root_sensor.add(obj_path,Sensors.PowerCap(bus,obj_path))
+	sensor_obj = Sensors.PowerCap(bus,obj_path)
+	## hwmon3 is default for master OCC on Barreleye.
+	## should rewrite sensor_manager to remove hardcode
+	sensor_obj.sysfs_attr = "/sys/class/hwmon/hwmon3/user_powercap"
+	root_sensor.add(obj_path,sensor_obj)
+
 	obj_path = OBJ_PATH+"/host/BootProgress"
 	root_sensor.add(obj_path,Sensors.BootProgressSensor(bus,obj_path))
 	obj_path = OBJ_PATH+"/host/OccStatus"


### PR DESCRIPTION
…ors/host/PowerCap

obmc uses dbus interface 'org.openbmc.SensorValue' of the object
'/org/openbmc/sensors/host/PowerCap' to set Host PowerCap.
Rewrite the setValue() method to set PowerCap via the
"/sys/class/hwmon/hwmonX/user_powercap" OCC-HWMON sysfs attribute.
BMC will sends a "Set User PowerCap" command to OCC.

Signed-off-by: Yi Li <adamliyi@msn.com>