### PR TITLE
skeleton: Update setValue() method dbus object '/org/openbmc/sensors/…

### DIFF
--- a/bin/Sensors.py
+++ b/bin/Sensors.py
@@ -163,6 +163,8 @@ class BootProgressSensor(VirtualSensor):
 		
 class OccStatusSensor(VirtualSensor):
 	def __init__(self,bus,name):
+		## default path. can be override
+		self.sysfs_attr = "/sys/class/i2c-adapter/i2c-3/3-0050/online"
 		VirtualSensor.__init__(self,bus,name)
 		self.setValue("Disabled")
 		bus.add_signal_receiver(self.SystemStateHandler,signal_name = "GotoSystemState")
@@ -170,7 +172,6 @@ class OccStatusSensor(VirtualSensor):
 	def SystemStateHandler(self,state):
 		if (state == "HOST_POWERED_OFF"):
 			self.setValue("Disabled")
-			
 
 	##override setValue method
 	@dbus.service.method(SensorValue.IFACE_NAME,
@@ -178,14 +179,10 @@ class OccStatusSensor(VirtualSensor):
 	def setValue(self,value):
 		if (value == "Enabled"):
 			print "Installing OCC device"
-			os.system("echo occ-i2c 0x50 >  /sys/bus/i2c/devices/i2c-3/new_device")
-			os.system("echo occ-i2c 0x51 >  /sys/bus/i2c/devices/i2c-3/new_device")
+			os.system("echo 1 > " +  self.sysfs_attr)
 		else:
 			print "Deleting OCC device"
-			os.system("echo 0x50 >  /sys/bus/i2c/devices/i2c-3/delete_device")
-			os.system("echo 0x51 >  /sys/bus/i2c/devices/i2c-3/delete_device")
-
-
+			os.system("echo 0 > " +  self.sysfs_attr)
 		SensorValue.setValue(self,value)
 			
 	@dbus.service.signal(CONTROL_IFACE,signature='s')

--- a/bin/sensor_manager2.py
+++ b/bin/sensor_manager2.py
@@ -56,8 +56,12 @@ if __name__ == '__main__':
 	root_sensor.add(obj_path,Sensors.PowerCap(bus,obj_path))
 	obj_path = OBJ_PATH+"/host/BootProgress"
 	root_sensor.add(obj_path,Sensors.BootProgressSensor(bus,obj_path))
+
 	obj_path = OBJ_PATH+"/host/OccStatus"
-	root_sensor.add(obj_path,Sensors.OccStatusSensor(bus,obj_path))
+	sensor_obj = Sensors.OccStatusSensor(bus,obj_path)
+	sensor_obj.sysfs_attr = "/sys/class/i2c-adapter/i2c-3/3-0050/online"
+	root_sensor.add(obj_path,sensor_obj)
+
 	obj_path = OBJ_PATH+"/host/BootCount"
 	root_sensor.add(obj_path,Sensors.BootCountSensor(bus,obj_path))
 	obj_path = OBJ_PATH+"/host/OperatingSystemStatus"


### PR DESCRIPTION
…host/OccStatus'

In recent occ_i2c driver, a new hwmon sysfs attribte
'/sys/class/i2c-adapter/i2c-X/X-0050/online' has been used to
instantiate occ_i2c device. Update the 'OccStatus' dbus object
to use the new interface.
Do not use '/sys/class/i2c-adapter/i2c-X/new_device' anymore.

Signed-off-by: Yi Li <adamliyi@msn.com>