### PR TITLE
Stop watchdog on power off

### DIFF
--- a/bin/chassis_control.py
+++ b/bin/chassis_control.py
@@ -118,6 +118,8 @@ class ChassisControlObject(Openbmc.DbusProperties,Openbmc.DbusObjectManager):
 		in_signature='', out_signature='')
 	def powerOff(self):
 		print "Turn off power"
+		intfwatchdog = self.getInterface('watchdog')
+		intfwatchdog.stop()
 		intf = self.getInterface('power_control')
 		intf.setPowerState(POWER_OFF)
 		return None

--- a/objects/host_watchdog_obj.c
+++ b/objects/host_watchdog_obj.c
@@ -33,6 +33,16 @@ poll_watchdog(gpointer user_data)
 }
 
 static gboolean
+remove_watchdog(void)
+{
+    if (watchdogid)
+    {
+        g_source_remove(watchdogid);
+        watchdogid = 0;
+    }
+}
+
+static gboolean
 set_poll_interval (Watchdog  *wd,
                 GDBusMethodInvocation  *invocation,
                 guint                   interval,
@@ -48,6 +58,7 @@ on_start        (Watchdog  *wd,
                 GDBusMethodInvocation  *invocation,
                 gpointer                user_data)
 {
+  	remove_watchdog();
   	watchdog_set_watchdog(wd,1);
 	guint poll_interval = watchdog_get_poll_interval(wd);
     g_print("Starting watchdog with poll interval: %d\n", poll_interval);
@@ -72,13 +83,7 @@ on_stop         (Watchdog  *wd,
                 gpointer                user_data)
 {
     g_print("Stopping watchdog\n");
-
-    if (watchdogid)
-    {
-        g_source_remove(watchdogid);
-        watchdogid = 0;
-    }
-
+    remove_watchdog();
     watchdog_complete_stop(wd,invocation);
     return TRUE;
 }


### PR DESCRIPTION
Stop watchdog on a power off request so that it does not
expire if the system is powered off in the middle of a power on.
Clear any existing watchdog timers before honoring a start
watchdog request so that there is only one timer at a time.