### PR TITLE
Re-enable host watchdog

### DIFF
--- a/bin/chassis_control.py
+++ b/bin/chassis_control.py
@@ -187,8 +187,8 @@ class ChassisControlObject(Openbmc.DbusProperties,Openbmc.DbusObjectManager):
 		
 	def host_watchdog_signal_handler(self):
 		print "Watchdog Error, Hard Rebooting"
-		#self.Set(DBUS_NAME,"reboot",1)
-		#self.powerOff()
+		self.Set(DBUS_NAME,"reboot",1)
+		self.powerOff()
 
 	def emergency_shutdown_signal_handler(self):
 		print "Emergency Shutdown!"


### PR DESCRIPTION
Re-enabling the host watchdog.
It was commented out due to a unhandled use case during power off,
and this use case has been addressed.