### PR TITLE
Fix host watchdog timer taking double the time to expire

### DIFF
--- a/objects/host_watchdog_obj.c
+++ b/objects/host_watchdog_obj.c
@@ -59,7 +59,7 @@ on_start        (Watchdog  *wd,
                 gpointer                user_data)
 {
   	remove_watchdog();
-  	watchdog_set_watchdog(wd,1);
+  	watchdog_set_watchdog(wd,0);
 	guint poll_interval = watchdog_get_poll_interval(wd);
     g_print("Starting watchdog with poll interval: %d\n", poll_interval);
   	watchdogid = g_timeout_add(poll_interval, poll_watchdog, user_data);


### PR DESCRIPTION
The g_timeout_add() glib interface does not spawn immediately after it's called
but instead it runs for the first time after the specified interval.

Therefore need to set the watchdog property to 0 instead of 1 when the watchdog starts, and let
subsequent watchdog refresh calls set it to 1, otherwise the watchdog timer expires in double the time that was specified: it waits the interval time and sees it's 1 then waits a 2nd round to see it's 0.