### PR TITLE
Update hconsole to account for background sessions

### DIFF
--- a/bin/hconsole
+++ b/bin/hconsole
@@ -2,6 +2,12 @@
 
 echo "Ctrl-a k  to exit console"
 echo "A session log is created in current directory"
+if screen -list | grep "hostconsole" | grep -q -i "Detached"; then
+  echo "You have an existing detached console session to host, you will be reconnected to that session"
+fi
+if screen -list | grep "hostconsole" | grep -q -i "Attached"; then
+  echo "You have an existing attached console session to host, you will be detached from that session and reconnected here instead"
+fi
 echo "[Enter] to continue"
 read a
-screen -U /dev/ttyS5
+screen -dR hostconsole -U /dev/ttyS5


### PR DESCRIPTION
Proposed change accounts for users connecting to host through "hconsole" who:
a. Have no existing screen sessions to host console
b. Have an existing attached screen session to host console
c. Have an existing detached screen session to host console

ADVANTAGE 1: Accounting for attached screen sessions in background
WITHOUT this change: When a user connected to host via 'hconsole', accidentally gets disconnected from ssh session, they would have an active screen session to host in background. When same user logs back in and executes 'hconsole' to get back to the host console, he would create a new screen session resulting in lost serial data between these parallel screen sessions on same tty.
WITH this change: Said user can ssh back into BMC and execute hconsole and it will :
a) Detach the existing host screen session 
b) Reattach to the same 
c) His previous state will be preserved.

ADVANTAGE 2: Accounting for dettached screen sessions in background
WITHOUT this change: If user doesn't want to kill the host screen session and disconnect instead, one cannot execute "hconsole" to reattach to the previously detached session. 
WITH this change: User connected to host via 'hconsole' can chose to disconnect from host console screen session instead of killing it. When user wants to get back to the console, one need not actively monitor for existing screen sessions and reconnect to it. Instead one can just type 'hconsole' and it would automatically reconnect to the existing session and the state would be preserved.

PRESERVING PREVIOUS FUNCTIONALITY:
If a user with no background screen sessions to host types 'hconsole' , a new screen session will be created (as done previously ) with a name 'hostconsole'. This would help him differentiate between additional screen sessions he may create on BMC itself and BMC-to-Host screen session.

SCREEN FLAGS USED:
-d  Detach the elsewhere running screen (if exists).
-R Reattach if possible, otherwise start a new session. 
-U Tell screen to use UTF-8 encoding.

TESTING:
Executed 'hconsole' command from modified source in following cases:
a) With NO screen sessions in background
b) With just local BMC sessions in background
c) With BMC-to-Host detached screen sessions in background
d) With BMC-to-Host attached screen sessions in background
e) Combination or (a)  and (b)
f) Combination of (b) and (c or d)