### PR TITLE
Updated SCU88 register for Correct PCIe inventory

### DIFF
--- a/objects/control_bmc_barreleye.c
+++ b/objects/control_bmc_barreleye.c
@@ -94,10 +94,10 @@ void reg_init()
 	bmcreg = memmap(mem_fd,GPIO_BASE);
 	devmem(bmcreg+0x84,0x00fff0c0);  //Enable UART1
 	devmem(bmcreg+0x80,0xCB000000);
-	devmem(bmcreg+0x88,0x01C000FF);
+	devmem(bmcreg+0x88,0x01C00000);		//Changed Assigned value to SCU 88 for PCie inventory to work
 	devmem(bmcreg+0x8c,0xC1C000FF);
 	devmem(bmcreg+0x90,0x003FA009);
-	devmem(bmcreg+0x88,0x01C0007F);
+	// devmem(bmcreg+0x88,0x01C0007F);	// Commented out to prevent dual assignment of SCU88
 
 
 	bmcreg = memmap(mem_fd,COM_BASE);


### PR DESCRIPTION
Before This change:
a) SCU 88 was double assigned, first to 0x01C000FF in line:97 and then to 0x01C0007F in line:100. 
b) Which meant (in both cases, some or all of) bits 7:0 were set to 1. That is: We were reading : PWMx or VPIGx instead of GPIONx (GPIONx gives us the PCIe inventory status, where x is bit number)

After This Change:
a) Got rid of the double assignment by commenting out the second SCU88 assignment
b) Bits (7:0) of SCU 88 are set to 0 . (According to Page 111 of data sheet these have to be set to 0 for us to to read GPION0 to GPIO N7 which indicate if PCIe device is present )

Description of pins 7:0 of SCU 88:
7 RW Enable PWM7 or VPIG7 function pin  (SCU90[5:4]=0x2 select Video pin)
6 RW Enable PWM6 or VPIG6 function pin   (SCU90[5:4]=0x2 select Video pin)
5 RW Enable PWM5 or VPIG5 function pin    (SCU90[5:4]!=0 select Video pin)
4 RW Enable PWM4 or VPIG4 function pin     (SCU90[5:4]!=0 select Video pin)
3 RW Enable PWM3 or VPIG3 function pin      (SCU90[5:4]!=0 select Video pin)
2 RW Enable PWM2 or VPIG2 function pin        (SCU90[5:4]!=0 select Video pin)
1 RW Enable PWM1 or VPIG1 function pin        (SCU90[5:4]=0x3 select Video pin)
0 RW Enable PWM0 or VPIG0 function pin         (SCU90[5:4]=0x3 select Video pin)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Review on Reviewable"/>](https://reviewable.io/reviews/openbmc/skeleton/55)
<!-- Reviewable:end -->
