### PR TITLE
Replace BUILD_ID with VERSION_ID in then inventory

### DIFF
--- a/bin/inventory_items.py
+++ b/bin/inventory_items.py
@@ -71,7 +71,7 @@ def getVersion():
 		for line in f:
 			p = line.rstrip('\n')
 			parts = line.rstrip('\n').split('=')
-			if (parts[0] == "BUILD_ID"):
+			if (parts[0] == "VERSION_ID"):
 				version = parts[1]
 	return version
 


### PR DESCRIPTION
Add VERSION_ID to the inventory instead of BUILD_ID because
the version (git tag) is the value that gets updated during
a firmware update, the build id remains constant.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openbmc/skeleton/63)
<!-- Reviewable:end -->
