### PR TITLE
Allow sysfs path to be passed to OCC sensor

### DIFF
--- a/bin/Sensors.py
+++ b/bin/Sensors.py
@@ -176,9 +176,12 @@ class BootProgressSensor(VirtualSensor):
 		pass
 		
 class OccStatusSensor(VirtualSensor):
-	def __init__(self,bus,name):
+	def __init__(self,bus,name, sysfs = None):
 		## default path. can be override
-		self.sysfs_attr = "/sys/class/i2c-adapter/i2c-3/3-0050/online"
+		if sysfs is None:
+			self.sysfs_attr = "/sys/class/i2c-adapter/i2c-3/3-0050/online"
+		else:
+			self.sysfs_attr = sysfs
 		VirtualSensor.__init__(self,bus,name)
 		self.setValue("Disabled")
 		bus.add_signal_receiver(self.SystemStateHandler,signal_name = "GotoSystemState")


### PR DESCRIPTION
The previous method of overriding this didn't work because
the base class constructor disables the sensor before the path
is updated with the correct one.

Pass it into the constructor so that the path is correct from
the beginning.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openbmc/skeleton/65)
<!-- Reviewable:end -->
