### PR TITLE
Remove CHASSIS_2 from Barreleye.py

### DIFF
--- a/bin/Barreleye.py
+++ b/bin/Barreleye.py
@@ -385,7 +385,6 @@ ID_LOOKUP = {
 		'BOARD_3'    : '<inventory_root>/system/misc',
 		'PRODUCT_51' : '<inventory_root>/system/misc',
 		'PRODUCT_100': '<inventory_root>/system',
-		'CHASSIS_2'  : '<inventory_root>/system/chassis',
 		'CHASSIS_100': '<inventory_root>/system/chassis',
 		'BOARD_100'  : '<inventory_root>/system/chassis/io_board',
 		'BOARD_101'  : '<inventory_root>/system/chassis/sas_expander',


### PR DESCRIPTION
FRU_ID 2 corresponds to CPU1 and it doesn't have a CHASSIS section,
so removing CHASSIS_2 since it causes an error on parsing the vpd
data from hostboot and therefore it doesn't get added to the
inventory.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openbmc/skeleton/68)
<!-- Reviewable:end -->
