### PR TITLE
Add BMC Flash dbus object to Palmetto

### DIFF
--- a/bin/Palmetto.py
+++ b/bin/Palmetto.py
@@ -123,6 +123,12 @@ APPS = {
 		'monitor_process' : True,
 		'process_name'    : 'flash_bios.exe',
 	},
+	'bmc_flash_control' : {
+		'system_state'    : 'BMC_STARTING',
+		'start_process'   : True,
+		'monitor_process' : True,
+		'process_name'    : 'bmc_update.py',
+	},
 	'download_manager' : {
 		'system_state'    : 'BMC_STARTING',
 		'start_process'   : True,


### PR DESCRIPTION
Add the BMC Flash dbus object to Palmetto.py to expose interfaces
to flash the BMC. Without it, there are no interfaces to flash BMC
from REST. This change is already in Barreleye, just porting to Palmetto.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openbmc/skeleton/69)
<!-- Reviewable:end -->
