### PR TITLE
Wait for init done before claiming bus name

### DIFF
--- a/bin/inventory_items.py
+++ b/bin/inventory_items.py
@@ -79,7 +79,6 @@ def getVersion():
 if __name__ == '__main__':
     dbus.mainloop.glib.DBusGMainLoop(set_as_default=True)
     bus = Openbmc.getDBus()
-    name = dbus.service.BusName(DBUS_NAME,bus)
     mainloop = gobject.MainLoop()
     obj_parent = Inventory(bus, '/org/openbmc/inventory')
 
@@ -94,6 +93,7 @@ if __name__ == '__main__':
 		version = getVersion()
 		obj.update({'version': version})
 
+    name = dbus.service.BusName(DBUS_NAME,bus)
     print "Running Inventory Manager"
     mainloop.run()
 


### PR DESCRIPTION
Wait for initialization to complete before claiming a well known
bus name.  This allows other applications to use a NameOwnerChanged
signal as an indication that service initialization has completed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openbmc/skeleton/70)
<!-- Reviewable:end -->
