### PR TITLE
[skeleton]: Fix hard-coded path name when creating sensor object

### DIFF
--- a/bin/Barreleye.py
+++ b/bin/Barreleye.py
@@ -718,3 +718,16 @@ HWMON_CONFIG = {
 	},
 }
 
+# Miscellaneous non-poll sensor with system specific properties.
+# The sensor id is the same as those defined in ID_LOOKUP['SENSOR'].
+MISC_SENSORS = {
+	0x09 : { 'class' : 'BootCountSensor' },
+	0x05 : { 'class' : 'BootProgressSensor' },
+	0x08 : { 'class' : 'OccStatusSensor',
+		'os_path' : '/sys/class/i2c-adapter/i2c-3/3-0050/online' },
+	0x0A : { 'class' : 'OccStatusSensor',
+		'os_path' : '/sys/class/i2c-adapter/i2c-3/3-0051/online' },
+	0x32 : { 'class' : 'OperatingSystemStatusSensor' },
+	0x33 : { 'class' : 'PowerCap',
+		'os_path' : '/sys/class/hwmon/hwmon3/user_powercap' },
+}

--- a/bin/Firestone.py
+++ b/bin/Firestone.py
@@ -608,3 +608,18 @@ HWMON_CONFIG = {
         }
     },
 }
+
+
+# Miscellaneous non-poll sensor with system specific properties.
+# The sensor id is the same as those defined in ID_LOOKUP['SENSOR'].
+MISC_SENSORS = {
+	0x5f : { 'class' : 'BootCountSensor' },
+	0x05 : { 'class' : 'BootProgressSensor' },
+	0x08 : { 'class' : 'OccStatusSensor',
+		'os_path' : '/sys/class/i2c-adapter/i2c-3/3-0050/online' },
+	0x09 : { 'class' : 'OccStatusSensor',
+		'os_path' : '/sys/class/i2c-adapter/i2c-3/3-0051/online' },
+	0xb5 : { 'class' : 'OperatingSystemStatusSensor' },
+	0xb3 : { 'class' : 'PowerCap',
+		'os_path' : '/sys/class/hwmon/hwmon3/user_powercap' },
+}

--- a/bin/Garrison.py
+++ b/bin/Garrison.py
@@ -608,3 +608,17 @@ HWMON_CONFIG = {
         }
     },
 }
+
+# Miscellaneous non-poll sensor with system specific properties.
+# The sensor id is the same as those defined in ID_LOOKUP['SENSOR'].
+MISC_SENSORS = {
+	0x5f : { 'class' : 'BootCountSensor' },
+	0x05 : { 'class' : 'BootProgressSensor' },
+	0x08 : { 'class' : 'OccStatusSensor',
+		'os_path' : '/sys/class/i2c-adapter/i2c-3/3-0050/online' },
+	0x09 : { 'class' : 'OccStatusSensor',
+		'os_path' : '/sys/class/i2c-adapter/i2c-3/3-0051/online' },
+	0xb5 : { 'class' : 'OperatingSystemStatusSensor' },
+	0xb3 : { 'class' : 'PowerCap',
+		'os_path' : '/sys/class/hwmon/hwmon3/user_powercap' },
+}

--- a/bin/Palmetto.py
+++ b/bin/Palmetto.py
@@ -306,3 +306,15 @@ HWMON_CONFIG = {
 		}
 	}
 }
+
+# Miscellaneous non-poll sensor with system specific properties.
+# The sensor id is the same as those defined in ID_LOOKUP['SENSOR'].
+MISC_SENSORS = {
+	0x09 : { 'class' : 'BootCountSensor' },
+	0x05 : { 'class' : 'BootProgressSensor' },
+	0x08 : { 'class' : 'OccStatusSensor',
+		'os_path' : '/sys/class/i2c-adapter/i2c-3/3-0050/online' },
+	0x32 : { 'class' : 'OperatingSystemStatusSensor' },
+	0x33 : { 'class' : 'PowerCap',
+		'os_path' : '/sys/class/hwmon/hwmon1/user_powercap' },
+}

--- a/bin/sensor_manager2.py
+++ b/bin/sensor_manager2.py
@@ -9,6 +9,8 @@ import dbus.mainloop.glib
 import Openbmc
 import Sensors
 
+System = __import__(sys.argv[1])
+
 DBUS_NAME = 'org.openbmc.Sensors'
 OBJ_PATH = '/org/openbmc/sensors'
 
@@ -50,32 +52,13 @@ if __name__ == '__main__':
 
 	## instantiate non-polling sensors
 	## these don't need to be in seperate process
-	## TODO: this should not be hardcoded
-
-	obj_path = OBJ_PATH+"/host/PowerCap"
-	sensor_obj = Sensors.PowerCap(bus,obj_path)
-	## hwmon3 is default for master OCC on Barreleye.
-	## should rewrite sensor_manager to remove hardcode
-	sensor_obj.sysfs_attr = "/sys/class/hwmon/hwmon3/user_powercap"
-	root_sensor.add(obj_path,sensor_obj)
-
-	obj_path = OBJ_PATH+"/host/BootProgress"
-	root_sensor.add(obj_path,Sensors.BootProgressSensor(bus,obj_path))
-
-	obj_path = OBJ_PATH+"/host/cpu0/OccStatus"
-	sensor_obj = Sensors.OccStatusSensor(bus,obj_path)
-	sensor_obj.sysfs_attr = "/sys/class/i2c-adapter/i2c-3/3-0050/online"
-	root_sensor.add(obj_path,sensor_obj)
-
-	obj_path = OBJ_PATH+"/host/cpu1/OccStatus"
-	sensor_obj = Sensors.OccStatusSensor(bus,obj_path)
-	sensor_obj.sysfs_attr = "/sys/class/i2c-adapter/i2c-3/3-0051/online"
-	root_sensor.add(obj_path,sensor_obj)
-
-	obj_path = OBJ_PATH+"/host/BootCount"
-	root_sensor.add(obj_path,Sensors.BootCountSensor(bus,obj_path))
-	obj_path = OBJ_PATH+"/host/OperatingSystemStatus"
-	root_sensor.add(obj_path,Sensors.OperatingSystemStatusSensor(bus,obj_path))
+	for (id, the_sensor) in System.MISC_SENSORS.items():
+		sensor_class = the_sensor['class']
+		obj_path = System.ID_LOOKUP['SENSOR'][id]
+		sensor_obj = getattr(Sensors, sensor_class)(bus, obj_path)
+		if 'os_path' in the_sensor:
+			sensor_obj.sysfs_attr = the_sensor['os_path']
+		root_sensor.add(obj_path, sensor_obj)
 
 	mainloop = gobject.MainLoop()
 	print "Starting sensor manager"


### PR DESCRIPTION
This patch fixes skeleton issue: https://github.com/openbmc/skeleton/issues/33
The non-poll sensors have system specific properties. Define the sensor properties
in system files, and generate sensor objects dynamically.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openbmc/skeleton/72)
<!-- Reviewable:end -->
