### PR TITLE
Bug fixes for REST API flags related to updating BMC firmware

### DIFF
--- a/bin/bmc_update.py
+++ b/bin/bmc_update.py
@@ -103,7 +103,7 @@ class BmcFlashControl(Openbmc.DbusProperties,Openbmc.DbusObjectManager):
 			tar.extractall(UPDATE_PATH,members=doExtract(tar,copy_files))
 			tar.close()
 
-			if (self.Get(DBUS_NAME,"clear_persistent_files") == False):
+			if (self.Get(DBUS_NAME,"clear_persistent_files") == True):
 				print "Removing persistent files"
 				os.unlink(UPDATE_PATH+"/whitelist")
 			if (self.Get(DBUS_NAME,"preserve_network_settings") == True):

--- a/bin/bmc_update.py
+++ b/bin/bmc_update.py
@@ -108,7 +108,7 @@ class BmcFlashControl(Openbmc.DbusProperties,Openbmc.DbusObjectManager):
 				os.unlink(UPDATE_PATH+"/whitelist")
 			if (self.Get(DBUS_NAME,"preserve_network_settings") == True):
 				print "Preserving network settings"
-				shutil.copy2("/dev/mtd2",UPDATE_PATH+"image-u-boot-env")
+				shutil.copy2("/dev/mtd2",UPDATE_PATH+"/image-u-boot-env")
 				
 		except Exception as e:
 			print e


### PR DESCRIPTION
This Pull Request has 2 commits, both fixing bugs with REST API flags related BMC firmware update.

1. Corrected the Path to backup image-u-boot-env

**With Current Code:** when "persist_network_settings" variable is set, This BMC update process via REST copied / backuped the "u-boot-env" image to a wrong location: /run/initramfsimage-u-boot-env
**With the Fixed / Updated Code:** Uboot env image is copied (correct) location: /run/initramfs/image-u-boot-env

2. 
Corrected the check for 'clear_persistent_files'

**Previously:** As a part of BMC firmware update via REST API process, "check_persistent_files" flag was being incorrectly checked. As a result persistent file system was cleaned even through  "check_persistent_files" flag was left at "0" (default)

**With Current Change:** Persistent file system was cleaned only if  "check_persistent_files" flag is set to "1" by the user.

Signed-off-by: Adi Gangidi adi.gangidi@rackspace.com

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openbmc/skeleton/79)
<!-- Reviewable:end -->
