### PR TITLE
Pull down GPIOQ7 for unlock identify LED when power on

### DIFF
--- a/bin/Barreleye.py
+++ b/bin/Barreleye.py
@@ -539,6 +539,7 @@ GPIO_CONFIG['POWER_BUTTON'] = { 'gpio_pin': 'E0', 'direction': 'both' }
 GPIO_CONFIG['PCIE_RESET']   = { 'gpio_pin': 'B5', 'direction': 'out' }
 GPIO_CONFIG['USB_RESET']    = { 'gpio_pin': 'B6', 'direction': 'out' }
 
+GPIO_CONFIG['IDBTN']       = { 'gpio_pin': 'Q7', 'direction': 'out' }
 GPIO_CONFIG['BMC_THROTTLE']       = { 'gpio_pin': 'J3', 'direction': 'out' }
 GPIO_CONFIG['RESET_BUTTON']       = { 'gpio_pin': 'E2', 'direction': 'both' }
 GPIO_CONFIG['CPLD_TCK']    	  =   { 'gpio_pin': 'P0', 'direction': 'out' }

--- a/objects/control_host_obj.c
+++ b/objects/control_host_obj.c
@@ -21,6 +21,7 @@ GPIO fsi_clk      = (GPIO){ "FSI_CLK" };
 GPIO fsi_enable   = (GPIO){ "FSI_ENABLE" };
 GPIO cronus_sel   = (GPIO){ "CRONUS_SEL" };
 GPIO Throttle     = (GPIO){ "BMC_THROTTLE" };
+GPIO idbtn     	  = (GPIO){ "IDBTN" };
 
 /* Bit bang patterns */
 
@@ -104,6 +105,7 @@ on_boot(ControlHost *host,
 		rc |= gpio_open(&fsi_enable);
 		rc |= gpio_open(&cronus_sel);
 		rc |= gpio_open(&Throttle);
+		rc |= gpio_open(&idbtn);
 		if(rc!=GPIO_OK) { break; }
 
 		//setup dc pins
@@ -111,6 +113,7 @@ on_boot(ControlHost *host,
 		rc |= gpio_write(&fsi_enable,1);
 		rc |= gpio_write(&fsi_clk,1);
 		rc |= gpio_write(&Throttle,1);
+		rc |= gpio_write(&idbtn,0);
 		if(rc!=GPIO_OK) { break; }
 
 		//data standy state
@@ -169,6 +172,7 @@ on_boot(ControlHost *host,
 	gpio_close(&fsi_enable);
 	gpio_close(&cronus_sel);
 	gpio_close(&Throttle);
+	gpio_close(&idbtn);
 
 	control_host_emit_booted(host);
 	return TRUE;
@@ -219,6 +223,7 @@ on_bus_acquired(GDBusConnection *connection,
 	gpio_init(connection,&fsi_enable);
 	gpio_init(connection,&cronus_sel);
 	gpio_init(connection,&Throttle);
+	gpio_init(connection,&idbtn);
 }
 
 static void


### PR DESCRIPTION
GPIOQ7 make the LED GPIOH2 can not control when power on. So we need to pull down when init.

Signed-off-by: Ken Liu ken.th.liu@foxconn.com

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openbmc/skeleton/85)
<!-- Reviewable:end -->
