### PR TITLE
Read vpd from motherboard and add it to the inventory

### DIFF
--- a/bin/Barreleye.py
+++ b/bin/Barreleye.py
@@ -190,6 +190,13 @@ APPS = {
 		'process_name'    : 'phosphor-read-eeprom',
 		'args'            : ['--eeprom','/sys/bus/i2c/devices/0-0050/eeprom','--fruid','64'],
 	},
+	'motherboard_vpd' : {
+		'system_state'    : 'BMC_STARTING2',
+		'start_process'   : True,
+		'monitor_process' : False,
+		'process_name'    : 'phosphor-read-eeprom',
+		'args'            : ['--eeprom','/sys/bus/i2c/devices/4-0054/eeprom','--fruid','3'],
+	},
 	'exp_vpd' : {
 		'system_state'    : 'BMC_STARTING2',
 		'start_process'   : True,


### PR DESCRIPTION
The motherboard eeprom is now modeled in the device tree in
Barreleye. Read its vpd with the rest of the eeproms and add
the info to the inventory.

Signed-off-by: Adriana Kobylak <anoo@us.ibm.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openbmc/skeleton/86)
<!-- Reviewable:end -->
