### PR TITLE
Add update rest interface to bmc

### DIFF
--- a/bin/bmc_update.py
+++ b/bin/bmc_update.py
@@ -49,6 +49,12 @@ class BmcFlashControl(Openbmc.DbusProperties,Openbmc.DbusObjectManager):
 		self.TftpDownload(ip,filename)
 		self.Set(DBUS_NAME,"status","Downloading")
 		
+	@dbus.service.method(DBUS_NAME,
+		in_signature='s', out_signature='')
+	def update(self,filename):
+		self.Set(DBUS_NAME,"filename",filename)
+		self.download_complete_handler(filename, filename)
+
 	@dbus.service.signal(DOWNLOAD_INTF,signature='ss')
 	def TftpDownload(self,ip,filename):
 		self.Set(DBUS_NAME,"filename",filename)


### PR DESCRIPTION
Currentling /org/openbmc/control/flash/bmc only has updateViaTftp
I am adding the update method to allow for bmc code updates with
requiring a remote tftp server.

Something like this will now work.  Ofcourse the update method is not in charge of getting the code on to the bmc server.  That's the job of something else (i.e. scp)
curl -k -H "Content-Type: application/json" -x POST -d "{\"data\": [\"/tmp/flash-barreleye\"]}" https://<ip>/org/openbmc/control/flash/bmc/action/update

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openbmc/skeleton/87)
<!-- Reviewable:end -->
