### PR TITLE
Add support for ID_BUTTON gpio in all systems

### DIFF
--- a/bin/Firestone.py
+++ b/bin/Firestone.py
@@ -466,7 +466,8 @@ GPIO_CONFIG['CP0_DEVICES_RESET_N'] = \
         {'gpio_pin': 'N3', 'direction': 'out'}
 GPIO_CONFIG['CP1_DEVICES_RESET_N'] = \
         {'gpio_pin': 'N5', 'direction': 'out'}
-
+GPIO_CONFIG['IDBTN']       = \
+        { 'gpio_pin': 'Q7', 'direction': 'out' }
 GPIO_CONFIG['FSI_DATA'] = \
         {'gpio_pin': 'A5', 'direction': 'out'}
 GPIO_CONFIG['FSI_CLK'] = \

--- a/bin/Garrison.py
+++ b/bin/Garrison.py
@@ -478,6 +478,8 @@ GPIO_CONFIG['CRONUS_SEL'] = \
 GPIO_CONFIG['BMC_THROTTLE'] = \
         {'gpio_pin': 'J3', 'direction': 'out'}
 
+GPIO_CONFIG['IDBTN']       = \
+    { 'gpio_pin': 'Q7', 'direction': 'out' }
 GPIO_CONFIG['POWER_BUTTON'] = \
         {'gpio_pin': 'E0', 'direction': 'both'}
 GPIO_CONFIG['RESET_BUTTON'] = \

--- a/bin/Palmetto.py
+++ b/bin/Palmetto.py
@@ -275,6 +275,7 @@ GPIO_CONFIG['POWER_PIN']  =   { 'gpio_pin': 'E1', 'direction': 'out'  }
 GPIO_CONFIG['CRONUS_SEL'] =   { 'gpio_pin': 'A6', 'direction': 'out'  }
 GPIO_CONFIG['PGOOD']      =   { 'gpio_pin': 'C7', 'direction': 'in'  }
 GPIO_CONFIG['BMC_THROTTLE'] = { 'gpio_pin': 'J3', 'direction': 'out' }
+GPIO_CONFIG['IDBTN']       = { 'gpio_pin': 'Q7', 'direction': 'out' }
 GPIO_CONFIG['POWER_BUTTON'] = { 'gpio_pin': 'E0', 'direction': 'both' }
 GPIO_CONFIG['PCIE_RESET']   = { 'gpio_pin': 'B5', 'direction': 'out' }
 GPIO_CONFIG['USB_RESET']    = { 'gpio_pin': 'B6', 'direction': 'out' }


### PR DESCRIPTION
There is a gpio that supports turning a LED in to an identify LED.
Changes where made to Barreleye to support it.  This commit adds
the support to the other systems

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openbmc/skeleton/95)
<!-- Reviewable:end -->
