### PR TITLE
Fix broken attempt at hwmon caching

### DIFF
--- a/pyhwmon/hwmon.py
+++ b/pyhwmon/hwmon.py
@@ -55,7 +55,7 @@ class Hwmons():
 		with open(filename, 'w') as f:
 			f.write(str(value)+'\n')
 
-	def should_update(attribute, value):
+	def should_update(self, attribute, value):
 		if attribute not in self.cache:
 			self.cache[attribute] = value
 			return True


### PR DESCRIPTION
This repairs a hwmon regression introduced with efc6897.

Signed-off-by: Brad Bishop <bradleyb@fuzziesquirrel.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openbmc/skeleton/102)
<!-- Reviewable:end -->
