### PR TITLE
rules.mk: Fix parallel build for 'make install'

### DIFF
--- a/rules.mk
+++ b/rules.mk
@@ -19,7 +19,7 @@ all: $(DEFAULT_ALL)
 $(BINS): %: %.o $(EXTRA_OBJS)
 	$(CC) $(CFLAGS) $(LDFLAGS) -o $@$(BIN_SUFFIX) $^ $(LDLIBS)
 
-install-bins:
+install-bins: $(BINS)
 	@mkdir -p $(DESTDIR)$(sbindir)
 	@for b in $(BINS); do \
 		install $$b$(BIN_SUFFIX) $(DESTDIR)$(sbindir) || exit 1; \


### PR DESCRIPTION
install-bins was missing a dependency on the binaries themselves.

Signed-off-by: Patrick Williams <patrick@stwcx.xyz>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openbmc/skeleton/109)
<!-- Reviewable:end -->
