### PR TITLE
dbus.Double and revert sensor cache

### DIFF
--- a/pyhwmon/hwmon.py
+++ b/pyhwmon/hwmon.py
@@ -39,7 +39,6 @@ class Hwmons():
 		self.hwmon_root = { }
 		self.scanDirectory()
 		gobject.timeout_add(DIR_POLL_INTERVAL, self.scanDirectory)   
-		self.cache = {}
 
 	def readAttribute(self,filename):
 		val = "-1"
@@ -55,30 +54,17 @@ class Hwmons():
 		with open(filename, 'w') as f:
 			f.write(str(value)+'\n')
 
-	def should_update(attribute, value):
-		if attribute not in self.cache:
-			self.cache[attribute] = value
-			return True
-
-		update = (value != self.cache[attribute])
-		self.cache[attribute] = value
-
-		return update
 
 	def poll(self,objpath,attribute):
 		try:
 			raw_value = int(self.readAttribute(attribute))
-			if self.should_update(attribute, raw_value):
-				obj = bus.get_object(SENSOR_BUS,objpath,introspect=False)
-				intf = dbus.Interface(obj,HwmonSensor.IFACE_NAME)
-				rtn = intf.setByPoll(raw_value)
-				if (rtn[0] == True):
-					self.writeAttribute(attribute,rtn[1])
+			obj = bus.get_object(SENSOR_BUS,objpath,introspect=False)
+			intf = dbus.Interface(obj,HwmonSensor.IFACE_NAME)
+			rtn = intf.setByPoll(raw_value)
+			if (rtn[0] == True):
+				self.writeAttribute(attribute,rtn[1])
 		except:
 			print "HWMON: Attibute no longer exists: "+attribute
-			self.sensors.pop(objpath,None)
-			if attribute in self.cache:
-				del self.cache[attribute]
 			return False
 
 

--- a/pyhwmon/hwmon.py
+++ b/pyhwmon/hwmon.py
@@ -55,7 +55,7 @@ class Hwmons():
 		with open(filename, 'w') as f:
 			f.write(str(value)+'\n')
 
-	def should_update(self, attribute, value):
+	def should_update(attribute, value):
 		if attribute not in self.cache:
 			self.cache[attribute] = value
 			return True

--- a/pytools/obmcutil
+++ b/pytools/obmcutil
@@ -16,6 +16,9 @@ def fix_byte(it,key,parent):
     elif (isinstance(it,dbus.Byte)):   
         if (key != None):              
                 parent[key] = int(it)  
+    elif (isinstance(it,dbus.Double)):
+        if (key != None):
+                parent[key] = float(it)
     else:                              
         pass                           
 


### PR DESCRIPTION
The sensor cache does not work.  The revert addresses https://github.com/openbmc/skeleton/issues/113.
The python json encoder has trouble converting dbus.Double to a float.  Floating point sensors were added with https://github.com/openbmc/skeleton/commit/a8260c83d6566fc46832c627ae32c996cfb76ea4.  Resolves https://github.com/openbmc/skeleton/issues/112.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openbmc/skeleton/114)
<!-- Reviewable:end -->
