### PR TITLE
Remove Chassis and Product area from IO Board

### DIFF
--- a/configs/Barreleye.py
+++ b/configs/Barreleye.py
@@ -405,8 +405,6 @@ ID_LOOKUP = {
 		'PRODUCT_0'  : '<inventory_root>/system/bios',
 		'BOARD_3'    : '<inventory_root>/system/misc',
 		'PRODUCT_51' : '<inventory_root>/system/misc',
-		'PRODUCT_100': '<inventory_root>/system',
-		'CHASSIS_100': '<inventory_root>/system/chassis',
 		'BOARD_100'  : '<inventory_root>/system/chassis/io_board',
 		'BOARD_101'  : '<inventory_root>/system/chassis/sas_expander',
 		'BOARD_102'  : '<inventory_root>/system/chassis/hdd_backplane',


### PR DESCRIPTION
Add argument to phosphor-read-eeprom to add additional handling
for reading the IO Board VPD.

Signed-off-by: Adriana Kobylak <anoo@us.ibm.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openbmc/skeleton/119)
<!-- Reviewable:end -->
