### PR TITLE
Add the missing binary into Palmetto config file

### DIFF
--- a/configs/Palmetto.py
+++ b/configs/Palmetto.py
@@ -154,6 +154,12 @@ APPS = {
 		'monitor_process' : True,
 		'process_name'    : 'chassis_control.py',
 	},
+	'restore' : {
+		'system_state'    : 'BMC_READY',
+		'start_process'   : True,
+		'monitor_process' : False,
+		'process_name'    : 'discover_system_state.py',
+	},
 	'bmc_control' : {
 		'system_state'    : 'BMC_STARTING',
 		'start_process'   : True,


### PR DESCRIPTION
Palmetto.py did not have discover_system_state.py and this patch is
to update that. discover_system_state.py is responsible for looking
at power restoration policy set by the user and then taking appropriate
actions when BMC comes back from any reboot / power cycle and reaches
BMC_READY state.  Actions could be :
1) Leave the system in power off state.
2) Power on the box.
3) Restore the last state which can be either #1 or #2 above.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openbmc/skeleton/122)
<!-- Reviewable:end -->
