### PR TITLE
hwmon: attribute is not polled after failure

### DIFF
--- a/pyhwmon/hwmon.py
+++ b/pyhwmon/hwmon.py
@@ -65,6 +65,7 @@ class Hwmons():
 				self.writeAttribute(attribute,rtn[1])
 		except:
 			print "HWMON: Attibute no longer exists: "+attribute
+			self.sensors.pop(objpath,None)
 			return False
 
 


### PR DESCRIPTION
This line of code was removed with revert bd01c24d (original efc68970)
but should not have been.  The line was originally added with 6956bbd4.

Signed-off-by: Brad Bishop <bradleyb@fuzziesquirrel.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openbmc/skeleton/125)
<!-- Reviewable:end -->
