### PR TITLE
skeleton: chassis_control - Add an ESEL when emergency shutdown host

### DIFF
--- a/pychassisctl/chassis_control.py
+++ b/pychassisctl/chassis_control.py
@@ -232,6 +232,18 @@ class ChassisControlObject(DbusProperties, DbusObjectManager):
 
     def emergency_shutdown_signal_handler(self):
         print "Emergency Shutdown!"
+        # log an esel
+        try:
+            obj = bus.get_object("org.openbmc.records.events",
+                                 "/org/openbmc/records/events", introspect=False)
+            intf = dbus.Interface(obj, "org.openbmc.recordlog")
+            desc = message
+            sev = "critical error"
+            details = "Get emergency shutdown signal. Shutdown the host."
+            debug = dbus.ByteArray("")
+            intf.acceptBMCMessage(desc, sev, details, debug)
+        except:
+            print "Emergency shutdown: log esel error."
         self.powerOff()
 
 


### PR DESCRIPTION
This patch fixes issue: https://github.com/openbmc/skeleton/issues/64
According to BMC Firmware Specification, on occasion the BMC will be required
to shut down the host due to high ambient or fan fails. A SEL must be
present in this case.

Signed-off-by: Yi Li <adamliyi@msn.com>

Change-Id: I65ea7e3284eab3e10e14604306f6d8e23f77d57e

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openbmc/skeleton/126)
<!-- Reviewable:end -->
